### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@ x10rf	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-init		KEYWORD2
+init	KEYWORD2
 RFXmeter	KEYWORD2
 RFXsensor	KEYWORD2
 x10Switch	KEYWORD2
@@ -21,7 +21,7 @@ x10Security	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-ON    LITERAL1
-OFF   LITERAL1
-BRIGHT  LITERAL1
-DIM   LITERAL1
+ON	LITERAL1
+OFF	LITERAL1
+BRIGHT	LITERAL1
+DIM	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords